### PR TITLE
Feat/store refector getProducts API CategoryId null 로 나오는 버그 해결

### DIFF
--- a/src/main/java/com/potato/ecommerce/domain/product/dto/ProductListResponse.java
+++ b/src/main/java/com/potato/ecommerce/domain/product/dto/ProductListResponse.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 public class ProductListResponse {
 
     private String name;
-    private Long productCategory;
+    private Long productCategoryId;
     private Long price;
     private Integer stock;
 }

--- a/src/main/java/com/potato/ecommerce/domain/product/dto/ProductListResponse.java
+++ b/src/main/java/com/potato/ecommerce/domain/product/dto/ProductListResponse.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 public class ProductListResponse {
 
     private String name;
-    private Long productCategoryId;
+    private Long productCategory;
     private Long price;
     private Integer stock;
 }

--- a/src/main/java/com/potato/ecommerce/domain/product/repository/ProductQueryRepositoryImpl.java
+++ b/src/main/java/com/potato/ecommerce/domain/product/repository/ProductQueryRepositoryImpl.java
@@ -27,7 +27,7 @@ public class ProductQueryRepositoryImpl implements ProductQueryRepository {
         List<ProductListResponse> products =
             queryFactory.select(fields(ProductListResponse.class,
                     product.name,
-                    product.productCategory.id,
+                    product.productCategory.id.as("productCategoryId"),
                     product.price,
                     product.stock))
                 .from(product)

--- a/src/main/java/com/potato/ecommerce/domain/product/repository/ProductQueryRepositoryImpl.java
+++ b/src/main/java/com/potato/ecommerce/domain/product/repository/ProductQueryRepositoryImpl.java
@@ -27,7 +27,7 @@ public class ProductQueryRepositoryImpl implements ProductQueryRepository {
         List<ProductListResponse> products =
             queryFactory.select(fields(ProductListResponse.class,
                     product.name,
-                    product.productCategory.id.as("productCategoryId"),
+                    product.productCategory.id,
                     product.price,
                     product.stock))
                 .from(product)


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
getProducts API CategoryId null 로 나오는 버그 해결
<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했는가?
- [ ] 코딩 컨벤션을 준수하였는가?
- [ ] 변경 사항에 대한 테스트를 했는가?(버그 수정/기능에 대한 테스트).
- [ ] 함수의 Parameter는 유효한 값을 가지고 있는가?
- [ ] 사용되는 변수들은 상황에 맞게 적절하게 선언되어 있는가?
- [ ] 변수들이 사용되기 전에 초기화되어 있는가?
- [ ] 계산에 사용되는 변수의 Data Type이 올바른가?
- [ ] 예외 처리가 잘 되어 있는가?
- [ ] 코드가 무한 루프에 빠지는 상황은 없는가?
- [ ] 매직 넘버는 상수로 처리했는가?
